### PR TITLE
Install Karpenter for autoscaling

### DIFF
--- a/terraform/resources/eks.tf
+++ b/terraform/resources/eks.tf
@@ -106,7 +106,7 @@ module "karpenter" {
   irsa_namespace_service_accounts = ["karpenter:karpenter"]
 
   create_iam_role = false
-  iam_role_arn = module.eks.eks_managed_node_groups["initial"].iam_role_arn
+  iam_role_arn = module.eks.eks_managed_node_groups["regular"].iam_role_arn
 
   tags = {
     Environment = "production"

--- a/terraform/resources/eks.tf
+++ b/terraform/resources/eks.tf
@@ -96,6 +96,24 @@ module "eks" {
   }
 }
 
+module "karpenter" {
+  source = "terraform-aws-modules/eks/aws//modules/karpenter"
+  version = "19.19.0"
+
+  cluster_name = module.eks.cluster_name
+
+  create_node_iam_role = false
+  node_iam_role_arn = module.eks.eks_managed_node_groups["regular"].iam_role_arn
+
+  # Since the nodegroup role will already have an access entry
+  create_access_entry = false
+
+  tags = {
+    Environment = "production"
+    Terraform   = "true"
+  }
+}
+
 # Secret for Django secret key
 
 resource "random_password" "django_secret_key" {

--- a/terraform/resources/eks.tf
+++ b/terraform/resources/eks.tf
@@ -102,15 +102,17 @@ module "karpenter" {
 
   cluster_name = module.eks.cluster_name
 
-  create_node_iam_role = false
-  node_iam_role_arn = module.eks.eks_managed_node_groups["regular"].iam_role_arn
+  irsa_oidc_provider_arn = module.eks.oidc_provider_arn
+  irsa_namespace_service_accounts = ["karpenter:karpenter"]
 
-  # Since the nodegroup role will already have an access entry
-  create_access_entry = false
+  create_iam_role = false
+  iam_role_arn = module.eks.eks_managed_node_groups["initial"].iam_role_arn
 
   tags = {
     Environment = "production"
-    Terraform   = "true"
+    Terraform = "true"
+    Project = "osmcha"
+    Karpenter = "true"
   }
 }
 

--- a/terraform/resources/eks.tf
+++ b/terraform/resources/eks.tf
@@ -102,6 +102,7 @@ module "karpenter" {
 
   cluster_name = module.eks.cluster_name
 
+  irsa_name = "karpenter-irsa"
   irsa_oidc_provider_arn = module.eks.oidc_provider_arn
   irsa_namespace_service_accounts = ["karpenter:karpenter"]
 


### PR DESCRIPTION
EKS doesn't ship with autoscaling by default and we have to run our own autoscaler. The two main options are [Karpenter](https://karpenter.sh/docs/) and [Cluster Autoscaler
](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md)
Going with Karpenter since it seems to be the more feature complete solution.

cc @batpad 